### PR TITLE
Added some thermal material properties

### DIFF
--- a/schema/cpacs_schema.xml
+++ b/schema/cpacs_schema.xml
@@ -16273,6 +16273,15 @@
           <description>description</description>
           <materialLaw>materialLaw</materialLaw>
         </postFailure>
+        <emissivityMap>
+            <waveLength mapType="vector">4e-7;7e-7;1e-5</waveLength>
+            <diffuseEmissivity mapType="vector">0.8;0.8;0.95</diffuseEmissivity>
+        </emissivityMap>
+        <thermalConductivity>236</thermalConductivity>
+        <specificHeatMap>
+            <temperature mapType="vector">293</temperature>
+            <specificHeat mapType="vector">897</specificHeat>
+        </specificHeatMap>
       </material>
       <composites>
         <composite>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -12427,6 +12427,39 @@ jonas.jepsen@dlr.de
 	</xsd:complexType>
 
 
+	<xsd:complexType name="emissivityMapType">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>Emissivity map, containing the diffuse emissivity of a material at different spectral lengths.</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>The emissivity of a material can vary with the spectral wave length. 
+							The vectors diffuseEmissivity and waveLength must have the same size to be valid. 
+							The data should be linearly interpolated.
+						</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:all>
+					<xsd:element name="waveLength" type="stringVectorBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Wave length in [m]</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="diffuseEmissivity" type="stringVectorBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Diffuse emissivity of the material</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:all>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
 
 
 	<xsd:complexType name="engineAnalysisType">
@@ -28218,56 +28251,8 @@ jonas.jepsen@dlr.de
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="specificHeatMap" minOccurs="0">
-						<xsd:complexType>
-							<xsd:annotation>
-								<xsd:documentation>
-									Specific heat map, containing the specific heat capacity of a material at different temperatures.
-								</xsd:documentation>
-							</xsd:annotation>
-							<xsd:complexContent>
-								<xsd:extension base="complexBaseType">
-									<xsd:all>
-										<xsd:element name="temperature" type="stringVectorBaseType">
-											<xsd:annotation>
-												<xsd:documentation>temperature in [K]</xsd:documentation>
-											</xsd:annotation>
-										</xsd:element>
-										<xsd:element name="specificHeat" type="stringVectorBaseType">
-											<xsd:annotation>
-												<xsd:documentation>specific heat capacity of the material in [J/(kg*K)]</xsd:documentation>
-											</xsd:annotation>
-										</xsd:element>
-									</xsd:all>
-								</xsd:extension>
-							</xsd:complexContent>
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="emissivityMap" minOccurs="0">
-						<xsd:complexType>
-							<xsd:annotation>
-								<xsd:documentation>
-									Emissivity map, containing the diffuse emissivity of a material at different spectral lengths.
-								</xsd:documentation>
-							</xsd:annotation>
-							<xsd:complexContent>
-								<xsd:extension base="complexBaseType">
-									<xsd:all>
-										<xsd:element name="waveLength" type="stringVectorBaseType">
-											<xsd:annotation>
-												<xsd:documentation>Wave length in [m]</xsd:documentation>
-											</xsd:annotation>
-										</xsd:element>
-										<xsd:element name="diffuseEmissivity" type="stringVectorBaseType">
-											<xsd:annotation>
-												<xsd:documentation>Diffuse emissivity of the material</xsd:documentation>
-											</xsd:annotation>
-										</xsd:element>
-									</xsd:all>
-								</xsd:extension>
-							</xsd:complexContent>
-						</xsd:complexType>
-					</xsd:element>
+					<xsd:element name="specificHeatMap" minOccurs="0" type="specificHeatMapType" />
+					<xsd:element name="emissivityMap" minOccurs="0" type="emissivityMapType" />
 				</xsd:sequence>
 				<xsd:attribute name="uID" type="xsd:string" use="optional"/>
 			</xsd:extension>
@@ -34415,6 +34400,39 @@ jonas.jepsen@dlr.de
 				<xsd:sequence>
 					<xsd:element maxOccurs="unbounded" name="sparSegment" type="sparSegmentType"/>
 				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType  name="specificHeatMapType">
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>Specific heat map, containing the specific heat capacity of a material at different temperatures.</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>The specific heat of a material can vary with the temperature. The vectors specificHeat and temperature
+							must have the same size to be valid. The data should be linearly interpolated.
+						</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:all>
+					<xsd:element name="temperature" type="stringVectorBaseType">
+						<xsd:annotation>
+							<xsd:documentation>temperature in [K]</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="specificHeat" type="stringVectorBaseType">
+						<xsd:annotation>
+							<xsd:documentation>specific heat capacity of the material in [J/(kg*K)]</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:all>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -28211,6 +28211,63 @@ jonas.jepsen@dlr.de
 						</xsd:annotation>
 					</xsd:element>
 					<xsd:element maxOccurs="unbounded" minOccurs="0" name="postFailure" type="postFailureType"/>
+					<xsd:element name="thermalConductivity" minOccurs="0" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>
+								thermal conductivity of the material in [W/(m*K)]
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="specificHeatMap" minOccurs="0">
+						<xsd:complexType>
+							<xsd:annotation>
+								<xsd:documentation>
+									Specific heat map, containing the specific heat capacity of a material at different temperatures.
+								</xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexContent>
+								<xsd:extension base="complexBaseType">
+									<xsd:all>
+										<xsd:element name="temperature" type="stringVectorBaseType">
+											<xsd:annotation>
+												<xsd:documentation>temperature in [K]</xsd:documentation>
+											</xsd:annotation>
+										</xsd:element>
+										<xsd:element name="specificHeat" type="stringVectorBaseType">
+											<xsd:annotation>
+												<xsd:documentation>specific heat capacity of the material in [J/(kg*K)]</xsd:documentation>
+											</xsd:annotation>
+										</xsd:element>				
+									</xsd:all>
+								</xsd:extension>
+							</xsd:complexContent>
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="emissivityMap" minOccurs="0">
+						<xsd:complexType>
+							<xsd:annotation>
+								<xsd:documentation>
+									Emissivity map, containing the diffuse emissivity of a material at different spectral lengths.
+								</xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexContent>
+								<xsd:extension base="complexBaseType">
+									<xsd:all>
+										<xsd:element name="waveLength" type="stringVectorBaseType">
+											<xsd:annotation>
+												<xsd:documentation>Wave length in [m]</xsd:documentation>
+											</xsd:annotation>
+										</xsd:element>
+										<xsd:element name="diffuseEmissivity" type="stringVectorBaseType">
+											<xsd:annotation>
+												<xsd:documentation>Diffuse emmisivity of the material</xsd:documentation>
+											</xsd:annotation>
+										</xsd:element>				
+									</xsd:all>
+								</xsd:extension>
+							</xsd:complexContent>
+						</xsd:complexType>
+					</xsd:element>
 				</xsd:sequence>
 				<xsd:attribute name="uID" type="xsd:string" use="optional"/>
 			</xsd:extension>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -28237,7 +28237,7 @@ jonas.jepsen@dlr.de
 											<xsd:annotation>
 												<xsd:documentation>specific heat capacity of the material in [J/(kg*K)]</xsd:documentation>
 											</xsd:annotation>
-										</xsd:element>				
+										</xsd:element>
 									</xsd:all>
 								</xsd:extension>
 							</xsd:complexContent>
@@ -28260,9 +28260,9 @@ jonas.jepsen@dlr.de
 										</xsd:element>
 										<xsd:element name="diffuseEmissivity" type="stringVectorBaseType">
 											<xsd:annotation>
-												<xsd:documentation>Diffuse emmisivity of the material</xsd:documentation>
+												<xsd:documentation>Diffuse emissivity of the material</xsd:documentation>
 											</xsd:annotation>
-										</xsd:element>				
+										</xsd:element>
 									</xsd:all>
 								</xsd:extension>
 							</xsd:complexContent>


### PR DESCRIPTION
As discussed in #435, I added the 3 basic material properties:

 - thermal conductivity
 - specific heat capacity
 - (diffuse) emissivity

What we should still discuss is, what unit we use for the spectral wave length. The options are meters, microns (preferred), or nanometers. Currently I am using meters for the definition.