### PR TITLE
Design performance

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -11951,6 +11951,7 @@ jonas.jepsen@dlr.de
 				<xsd:all>
 					<xsd:element minOccurs="0" name="designMissions" type="designMissionsType" />
                     <xsd:element minOccurs="0" name="phases" type="designMissionPhasesType" />
+                    <xsd:element minOccurs="0" name="pointPerformance" type="pointPerformanceType" />
 				</xsd:all>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -30505,6 +30506,41 @@ jonas.jepsen@dlr.de
 				<xsd:sequence>
 					<xsd:element maxOccurs="unbounded" minOccurs="2" name="point" type="pointYZType"/>
 				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
+    <xsd:complexType name="pointPerformanceType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>pointPerformanceType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>point performance as constraints in aircraft design</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element minOccurs="0" name="serviceCeilings" type="serviceCeilingsType">
+						<xsd:annotation>
+							<xsd:documentation>Service ceilings for the performance. Used for the flight envelope.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element minOccurs="0" name="turns" type="turnsType">
+						<xsd:annotation>
+							<xsd:documentation>Definition of turn performances
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="uID" type="xsd:string" use="optional"/>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -610,6 +610,7 @@ jonas.jepsen@dlr.de
                 <xsd:element name="header" type="headerType"/>
                 <xsd:element minOccurs="0" name="vehicles" type="vehiclesType"/>
                 <xsd:element minOccurs="0" name="missions" type="missionsType"/>
+                <xsd:element minOccurs="0" name="designPerformance" type="designPerformanceType"/>
                 <xsd:element minOccurs="0" name="airports" type="airportsType"/>
                 <xsd:element minOccurs="0" name="flights" type="flightsType"/>
                 <xsd:element minOccurs="0" name="airlines" type="airlinesType"/>
@@ -11646,6 +11647,238 @@ jonas.jepsen@dlr.de
 		</xsd:complexContent>
 	</xsd:complexType>
 
+
+    <xsd:complexType name="designMissionPhaseType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>designMissionPhaseType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>Design mission phase type, containing a mission phase for a pre-design mission
+						</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element name="mach" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>mach number for the mission phase</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="time" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>time/duration for the mission phase</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="statusEng" type="integerBaseType">
+						<xsd:annotation>
+							<xsd:documentation>status of engine for the mission phase</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="dir" type="stringBaseType">
+						<xsd:annotation>
+							<xsd:documentation>direction of the mission phase can be either "out" or "in"</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="climbAngle" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>climb angle for the mission phase</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="enginePerformanceMapUID" type="stringUIDBaseType">
+						<xsd:annotation>
+							<xsd:documentation>reference to the engine performance map used for the mission phase</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="range" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>range/distance for the mission phase</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="descentAngle" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>descent angle for the mission phase</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="endAltitude" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>the end altitude for the mission phase</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="massFraction" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>explicit mass fraction to be used for the mission phase</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="enginePerformanceMapUID" type="stringUIDBaseType">
+						<xsd:annotation>
+							<xsd:documentation>reference to the engine performance map used for the mission phase</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="uID" type="xsd:string" use="required" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
+    <xsd:complexType name="designMissionPhasesType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>designMissionPhasesType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>Design missions phase type, containing the different mission phases for pre-design missions
+						</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" name="phase" type="designMissionPhaseType" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
+    <xsd:complexType name="designMissionSegmentType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>designMissionSegmentType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>DesignMissionSegment type, containing a segment of a pre-design mission
+						</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element name="segmentType" type="stringBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Name of mission segment</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="phaseSequence" type="stringVectorBaseType">
+						<xsd:annotation>
+							<xsd:documentation>An ordered ; separated list of phases for the pre-design mission segment</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="uID" type="xsd:string" use="required" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
+	<xsd:complexType name="designMissionSegmentsType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>designMissionSegmentsType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>DesignMissionSegments type, containing the list of segments
+							of a pre-design mission</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" name="segment" type="designMissionSegmentType" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
+	<xsd:complexType name="designMissionType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>designMissionType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>Design mission type, containing a pre-design mission definition
+						</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element name="name" type="stringBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Name of design mission</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element minOccurs="0" name="description" type="stringBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Description of design mission</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="segmentSequence" type="stringVectorBaseType">
+						<xsd:annotation>
+							<xsd:documentation>An ordered ; separated list of design segment UIDs</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element   name="segments" type="designMissionSegmentsType" />
+				</xsd:sequence>
+				<xsd:attribute name="uID" type="xsd:string" use="required" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
+	<xsd:complexType name="designMissionsType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>designMissionsType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>Design missions type, containing the pre-design missions
+						</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" name="designMission" type="designMissionType" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
 	<xsd:complexType name="designParameterType">
 
 		<xsd:annotation>
@@ -11697,6 +11930,31 @@ jonas.jepsen@dlr.de
 		</xsd:complexContent>
 	</xsd:complexType>
 	
+	
+    <xsd:complexType name="designPerformanceType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>designPerformanceType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>DesignPerformance node, containing definitions for design points and design missions
+							for the predesign phase.</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:all>
+					<xsd:element minOccurs="0" name="designMissions" type="designMissionsType" />
+				</xsd:all>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
 	
 	<xsd:complexType name="designSetType">
 

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -11950,6 +11950,7 @@ jonas.jepsen@dlr.de
 			<xsd:extension base="complexBaseType">
 				<xsd:all>
 					<xsd:element minOccurs="0" name="designMissions" type="designMissionsType" />
+                    <xsd:element minOccurs="0" name="phases" type="designMissionPhasesType" />
 				</xsd:all>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -33852,7 +33853,63 @@ jonas.jepsen@dlr.de
 	</xsd:complexType>
 
 
+    <xsd:complexType name="serviceCeilingType">
 
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>serviceCeilingType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>Definition of a service ceiling
+						</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element name="altitude" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Altitude of service ceiling</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element minOccurs="0" name="statusEng" type="integerBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Status of the engine for the service ceiling</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="uID" type="xsd:string" use="required" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+    <xsd:complexType name="serviceCeilingsType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>serviceCeilingsType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>Holds the service ceiling definitions
+						</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" name="serviceCeiling" type="serviceCeilingType" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
 
 
 	<xsd:complexType name="shaftLinkedComponentsType">
@@ -37500,6 +37557,74 @@ jonas.jepsen@dlr.de
 					</xsd:element>
 					<xsd:element minOccurs="0" name="quasiSteadyRotation" type="quasiSteadyRotationType"/>
 				</xsd:all>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+    <xsd:complexType name="turnType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>turnType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>Definition of a turn for design performance evaluation
+						</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element name="mach" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>mach number during turn</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="nTurn" type="integerBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Number of turns</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+                    <xsd:element name="altitude" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Altitude at which the turn is performed</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element minOccurs="0" name="statusEng" type="integerBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Status of the engine for the service ceiling</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="uID" type="xsd:string" use="required" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+    <xsd:complexType name="turnsType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>turnsType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>Holds the definitions of the turns for design performance evaluation
+						</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" name="turn" type="turnType" />
+				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>


### PR DESCRIPTION
# 1) Problem description:
For the mission analysis in preliminary aircraft design processes, it is necessary to have a definition for the design missions. It needs to include all the segments which might be required to evaluate the mission constraints e.g. in form of a constraint diagram to find the optimal design point.
The current mission definition in CPACS was developed for more detailed mission definition but is not usable during the initial design stage where such information as particular runways are usually not considered.


# 2) Suggested Solution:
Category: NEW

We want to adress this issue by adding a design mission definition to CPACS which allows the definition of actual design missions which can be used to evaluate design constraints.
Design missions are separated into mission segments which are described as a combination of different phases. The definition of the phases includes the actual information on what is to be performed during the phase. Further details can be found in the example XML file.

# 3) Example:

[designPerformanceExample.zip](https://github.com/DLR-LY/CPACS/files/605896/designPerformanceExample.zip)

# 4) Schema:
See code comparison.

# 5) Documentation:
[CPACS Documentation.zip](https://github.com/DLR-LY/CPACS/files/605899/CPACS.Documentation.zip)

# 6) Waiting for review and comments/discussions...
