### PR TITLE
Added automated CI build of CPACS documentation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+# version format
+version: 2.3.1.{build}.0
+
+os: Visual Studio 2015
+
+artifacts:
+  - path: 'build/doc/*.chm'
+    name: Documentation
+
+install:
+    - cmd: 7z x -y c:\projects\cpacs\development\3rdparty.zip -oc:\projects\cpacs\development\
+
+platform: Any CPU
+
+configuration: Release
+
+build:
+    project: documentation\Cpacs_doc_project.shfbproj
+

--- a/createDocumentation.bat
+++ b/createDocumentation.bat
@@ -1,1 +1,1 @@
-C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe .\documentation\Cpacs_doc_project.shfbproj
+MSBuild.exe .\documentation\Cpacs_doc_project.shfbproj

--- a/documentation/Cpacs_doc_project.shfbproj
+++ b/documentation/Cpacs_doc_project.shfbproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
+    <SHFBROOT Condition=" '$(SHFBROOT)' == '' ">$(MSBuildThisFileDirectory)..\development\3rdparty\EWSoftware.SHFB.2015.10.10.0\Tools\</SHFBROOT>
     <!-- The configuration and platform will be used to determine which
          assemblies to include from solution and project documentation
          sources -->
@@ -8,7 +9,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{3a878a3e-6991-4790-9569-ef371a1e7e15}</ProjectGuid>
-    <SHFBSchemaVersion>1.9.9.0</SHFBSchemaVersion>
+    <SHFBSchemaVersion>2015.6.5.0</SHFBSchemaVersion>
     <!-- AssemblyName, Name, and RootNamespace are not used by SHFB but Visual
          Studio adds them anyway -->
     <AssemblyName>Documentation</AssemblyName>
@@ -65,7 +66,8 @@
     <CollectionTocStyle>Hierarchical</CollectionTocStyle>
     <IncludeFavorites>False</IncludeFavorites>
     <SandcastlePath>C:\Program Files (x86)\Sandcastle\</SandcastlePath>
-    <!-- <HtmlHelp1xCompilerPath>..\..\..\..\..\..\Tools\Html Workshop\</HtmlHelp1xCompilerPath> --> <!-- only required if help 1 compiler cannot be found automatically -->
+    <!-- <HtmlHelp1xCompilerPath>..\..\..\..\..\..\Tools\Html Workshop\</HtmlHelp1xCompilerPath> -->
+    <!-- only required if help 1 compiler cannot be found automatically -->
     <ProjectSummary>The Common Parametric Aircraft Configuration Schema %28CPACS%29 is a data definition for the air transportation system. CPACS enables engineers to exchange information between their tools. It is therefore a driver for multi-disciplinary and multi-fidelity design in distributed environments. CPACS describes the characteristics of aircraft, rotorcraft, engines, climate impact, fleets and mission in a structured, hierarchical manner. Not only product but also process information is stored in CPACS. The process information helps in setting up workflows for analysis modules. Due to the fact that CPACS follows a central model approach, the number of interfaces is reduced to a minimum</ProjectSummary>
     <BuildAssemblerVerbosity>AllMessages</BuildAssemblerVerbosity>
     <FrameworkVersion>.NET Framework 3.5</FrameworkVersion>
@@ -79,6 +81,7 @@
     <NamingMethod>Guid</NamingMethod>
     <Language>en-US</Language>
     <WorkingPath>..\build\doc\working\</WorkingPath>
+    <ComponentPath>$(MSBuildThisFileDirectory)..\development\3rdparty</ComponentPath>
   </PropertyGroup>
   <!-- There are no properties for these two groups but they need to appear in
        order for Visual Studio to perform the build. -->
@@ -132,7 +135,7 @@
       <ImageId>controls</ImageId>
       <AlternateText>controls</AlternateText>
     </Image>
-	<Image Include="engineNacelle.png">
+    <Image Include="engineNacelle.png">
       <ImageId>engineNacelle</ImageId>
       <AlternateText>engine nacelle</AlternateText>
     </Image>
@@ -288,7 +291,7 @@
       <ImageId>eulerAnglesInCoordSys</ImageId>
       <AlternateText>euler Angles In Coord Sys</AlternateText>
     </Image>
-	<Image Include="DOE OPT Hierarchy.png">
+    <Image Include="DOE OPT Hierarchy.png">
       <ImageId>DOE OPT Hierarchy</ImageId>
       <AlternateText>DOE definition structure</AlternateText>
     </Image>


### PR DESCRIPTION
I added appveyor CI integration to automatically build the CPACS documentation on commits and pull requests.

It already works fine, as can be seen here:
https://ci.appveyor.com/project/rainman110/cpacs/build/2.3.1.34.0

I needed to add a 3rdparty.zip file, which includes SandCastle and the XSD Plugin. I tried to use first the nuget packages of SandCastle, which didn't work. Hence, we have to host our own toolchain. I hope this is okay.

To activate appveyor CI for the official CPACS repository, you just have to signup on appveyor (https://www.appveyor.com/) and add the CPACS project.