### PR TITLE
introduce a reference to a structural element for the attachment of a…

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -27034,6 +27034,10 @@ jonas.jepsen@dlr.de
 					<xsd:element name="mainStrutWingAttachmentPinUID" type="stringUIDBaseType"/>
 					<xsd:element name="fuselageAttachmentFrameUID" type="stringUIDBaseType"/>
 					<xsd:element name="fuselageAttachmentStringerUID" type="stringUIDBaseType"/>
+                    <xsd:element name="structuralElementUID" type="stringBaseType" maxOccurs="1" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>reference to the structural element that comprises this connection. </xsd:documentation>
+                        </xsd:annotation></xsd:element>
 				</xsd:sequence>
 				<xsd:attribute name="uID" type="xsd:string" use="optional"/>
 			</xsd:extension>


### PR DESCRIPTION
… strut with a fuselgage of aircrafts with strut-braced-wings.

With this, several beams may be defined to introduce a structural connection between strut and fuselage. Prior to this change, it was intended to use multiple point constraints within the FEM model to connect these structures. Now, an explicit beam may be defined for this