### PR TITLE
Engine performance

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -13159,6 +13159,8 @@ jonas.jepsen@dlr.de
 			<xsd:extension base="complexBaseType">
 				<xsd:all>
 					<xsd:element name="name" type="stringBaseType"/>
+					<xsd:element name="bleedAirOfftake" type="doubleBaseType"/>
+					<xsd:element name="powerOfftake" type="doubleBaseType"/>
 					<xsd:element minOccurs="0" name="description" type="stringBaseType"/>
 					<xsd:element minOccurs="0" name="flightLevel" type="stringVectorBaseType">
 						<xsd:annotation>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -13253,6 +13253,12 @@ jonas.jepsen@dlr.de
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
+					<xsd:element minOccurs="0" name="eiSOx" type="stringVectorBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Emission index Sulfur Oxide
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 					<xsd:element minOccurs="0" name="eiSoot" type="stringVectorBaseType">
 						<xsd:annotation>
 							<xsd:documentation>Emission index Soot</xsd:documentation>


### PR DESCRIPTION
# 1) Problem Description
For a use case in the [AGILE project](http://www.agile-project.eu) additional engine performance data (bleedAirOfftake, powerOfftake and emission index for sulfur oxide) is required.

# 2) Suggested Solution
In this branch we added some additional parameters to the enginePerformanceMapType.

1. The emission index for sulfur oxide is analog to the nitrogen oxide emission index.
2. bleedAirOfftake and powerOfftake were added as single double values.

We assumed that the the bleedAirOfftake and powerOfftake are constant for each flight segment and a new enginePerformanceMap is used for each flight segment.
This approach was chosen to simplify the use of the data for mission simulation.
In case more flexibility is needed bleedAirOfftake and powerOfftake could also be defined as vectors as all of the other parameters, resulting in an even more dimensional data structure.

# 3) Example:

# 4) Schema:
See proposed schema.

# 5) Documentation:
See the automated check for a build documentation.