### PR TITLE
Use uncertaintyfunction that was defined but never used

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -12476,7 +12476,7 @@ jonas.jepsen@dlr.de
 				<xsd:attribute name="externalDataNodePath" type="xsd:string" use="optional"/>
 				<xsd:attribute name="externalFileName" type="xsd:string" use="optional"/>
 				<xsd:attribute name="externalDataDirectory" type="xsd:string" use="optional"/>
-				<xsd:attribute name="uncertaintyFunctionName" type="xsd:string" use="optional"/>
+				<xsd:attribute name="uncertaintyFunctionName" type="uncertaintyFunctionType" use="optional"/>
 				<xsd:attribute name="mu" type="xsd:double" use="optional"/>
 				<xsd:attribute name="delta" type="xsd:double" use="optional"/>
 				<xsd:attribute name="a" type="xsd:double" use="optional"/>
@@ -35261,7 +35261,7 @@ jonas.jepsen@dlr.de
 		<xsd:simpleContent>
 			<xsd:extension base="stringBaseType">
 				<xsd:attribute fixed="vector" name="mapType" type="xsd:string" use="required"/>
-				<xsd:attribute name="uncertaintyFunctionName" type="xsd:string" use="optional"/>
+				<xsd:attribute name="uncertaintyFunctionName" type="uncertaintyFunctionType" use="optional"/>
 				<xsd:attribute name="mu" type="xsd:string" use="optional"/>
 				<xsd:attribute name="delta" type="xsd:string" use="optional"/>
 				<xsd:attribute name="a" type="xsd:string" use="optional"/>
@@ -37371,7 +37371,6 @@ jonas.jepsen@dlr.de
 	</xsd:complexType>
 
 	<xsd:simpleType name="uncertaintyFunctionType">
-
 		<xsd:restriction base="xsd:string">
 			<xsd:enumeration value="GaussianNormalDistribution"/>
 			<xsd:enumeration value="ExponentialDistribution"/>


### PR DESCRIPTION
The simpletype definition was never used, and xsd:string used instead.
Please cross-check if this is correct.