### PR TITLE
Forced enum values of rotor, rotorHub, and rotorHubHinge

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -32693,13 +32693,20 @@ jonas.jepsen@dlr.de
 						</xsd:annotation>
 					</xsd:element>
 					<xsd:element name="transformation" type="transformationType"/>
-					<xsd:element name="type" type="stringBaseType">
+					<xsd:element name="type">
 						<xsd:annotation>
 							<xsd:documentation>Hinge type. Possible values: "flap", "pitch"
 								"leadLag". This is used to define the rotation axis of the hinge
 								(flap = y-axis in blade cs, pitch = x-axis in blade cs, lead-lag
 								= z-axis in blade cs).</xsd:documentation>
 						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:string">
+								<xsd:enumeration value="flap"/>
+								<xsd:enumeration value="pitch"/>
+								<xsd:enumeration value="leadLag"/>
+							</xsd:restriction>
+						</xsd:simpleType>
 					</xsd:element>
 					<xsd:element minOccurs="0" name="neutralPosition" type="doubleBaseType">
 						<xsd:annotation>
@@ -32794,11 +32801,19 @@ jonas.jepsen@dlr.de
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element minOccurs="0" name="type" type="stringBaseType">
+					<xsd:element minOccurs="0" name="type">
 						<xsd:annotation>
 							<xsd:documentation>Rotor head type. Possible values: "semiRigid",
 								"rigid", "articulated", "hingeless"</xsd:documentation>
 						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:string">
+								<xsd:enumeration value="semiRigid"/>
+								<xsd:enumeration value="rigid"/>
+								<xsd:enumeration value="articulated"/>
+								<xsd:enumeration value="hingeless"/>
+							</xsd:restriction>
+						</xsd:simpleType>
 					</xsd:element>
 					<xsd:element name="rotorBladeAttachments" type="rotorBladeAttachmentsType">
 						<xsd:annotation>
@@ -32893,12 +32908,20 @@ jonas.jepsen@dlr.de
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element minOccurs="0" name="type" type="stringBaseType">
+					<xsd:element minOccurs="0" name="type">
 						<xsd:annotation>
 							<xsd:documentation>Rotor type. Possible values: "mainRotor"
 								(default), "tailRotor", "fenestron" or "propeller"..
 							</xsd:documentation>
 						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:string">
+								<xsd:enumeration value="mainRotor"/>
+								<xsd:enumeration value="tailRotor"/>
+								<xsd:enumeration value="fenestron"/>
+								<xsd:enumeration value="propeller"/>
+							</xsd:restriction>
+						</xsd:simpleType>
 					</xsd:element>
 					<xsd:element minOccurs="0" name="nominalRotationsPerMinute" type="doubleBaseType">
 						<xsd:annotation>
@@ -37709,7 +37732,7 @@ jonas.jepsen@dlr.de
 			<xsd:extension base="complexBaseType">
 				<xsd:all>
 					<xsd:element minOccurs="0" name="wingPanelings" type="vSAeroWingPanelingsType"/>
-					<xsd:element minOccurs="0" name="fuselagePanelings">
+					<xsd:element minOccurs="0" name="fuselagePanelings" type="aeroFuseFuselagePanelingsType">
 						<xsd:annotation>
 							<xsd:documentation>Paneling for each fuselage</xsd:documentation>
 						</xsd:annotation>


### PR DESCRIPTION
Airbus developed a C++ code generator for cpacs/tigl. In order to force proper checks in our code, we have to integrate into the schema, whenever there are only some valid values for strings.

In this commit, we forced the type properties of rotor, rotorHub, and rotorHubHinge to be a particular value.