### PR TITLE
Changed type of from/toRelativeCircumference in guideCurves to double

### DIFF
--- a/schema/cpacs_schema.xml
+++ b/schema/cpacs_schema.xml
@@ -822,17 +822,38 @@
               </positioning>
             </positionings>
             <segments>
-              <segment uID="">
+              <segment uID="wing_segment1">
                 <name>name</name>
                 <description>description</description>
                 <fromElementUID>fromElementUID</fromElementUID>
                 <toElementUID>toElementUID</toElementUID>
                 <guideCurves>
-                  <guideCurve uID="">
+                  <guideCurve uID="wing_segment1_guide1">
                     <name>name</name>
                     <description>description</description>
                     <guideCurveProfileUID>guideCurveProfileUID</guideCurveProfileUID>
-                    <toRelativeCircumference>toRelativeCircumference</toRelativeCircumference>
+                    <fromRelativeCircumference>0.0</fromRelativeCircumference>
+                    <toRelativeCircumference>0.0</toRelativeCircumference>
+                    <tangent>
+                      <x>0.0</x>
+                      <y>0.0</y>
+                      <z>0.0</z>
+                    </tangent>
+                  </guideCurve>
+                </guideCurves>
+              </segment>
+              <segment uID="wing_segment2">
+                <name>name</name>
+                <description>description</description>
+                <fromElementUID>fromElementUID</fromElementUID>
+                <toElementUID>toElementUID</toElementUID>
+                <guideCurves>
+                  <guideCurve uID="wing_segment2_guide1">
+                    <name>name</name>
+                    <description>description</description>
+                    <guideCurveProfileUID>guideCurveProfileUID</guideCurveProfileUID>
+                    <fromGuideCurveUID>wing_segment1_guide1</fromGuideCurveUID>
+                    <toRelativeCircumference>0.0</toRelativeCircumference>
                     <tangent>
                       <x>0.0</x>
                       <y>0.0</y>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -18716,10 +18716,11 @@ jonas.jepsen@dlr.de
 							</xsd:element>
 						</xsd:sequence>
 						<xsd:sequence>
-							<xsd:element name="fromRelativeCircumference" type="stringUIDBaseType">
+							<xsd:element name="fromRelativeCircumference" type="doubleBaseType">
 								<xsd:annotation>
 									<xsd:documentation>Reference to the relative circumference
-										position from which the guide curve shall start.
+										position from which the guide curve shall start. Valid values
+									    are in the interval -1.0...1.0.
 									</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
@@ -18731,10 +18732,11 @@ jonas.jepsen@dlr.de
 						</xsd:sequence>
 					</xsd:choice>
 					<xsd:sequence>
-						<xsd:element name="toRelativeCircumference" type="stringUIDBaseType">
+						<xsd:element name="toRelativeCircumference" type="doubleBaseType">
 							<xsd:annotation>
-								<xsd:documentation>Reference to the relative circumference
-									position at which the guide curve shall end.
+								<xsd:documentation>The relative circumference
+									position at which the guide curve shall end. Valid values
+									are in the interval -1.0...1.0.
 								</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>


### PR DESCRIPTION
I had to change the type of from/toRelativeCircumference in guideCurves to double. This should be indeed a double and it is important for schema validation and code generators, that this type is correct.

Fixes #485 
