### PR TITLE
added a complexType for the cpacs root node

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -24,8 +24,10 @@ Blohmstrasse 20, 21079 Hamburg
 +49 40 42878 4597
 jonas.jepsen@dlr.de
 -->
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ddue="http://ddue.schemas.microsoft.com/authoring/2003/5" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:sd="http://schemas.xsddoc.codeplex.com/schemaDoc/2009/3" xmlns:xlink="http://www.w3.org/1999/xlink"><xsd:element name="cpacs">
-<xsd:annotation>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ddue="http://ddue.schemas.microsoft.com/authoring/2003/5" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:sd="http://schemas.xsddoc.codeplex.com/schemaDoc/2009/3" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<xsd:element name="cpacs" type="cpacsType"/>
+	<xsd:complexType name="cpacsType">
+		<xsd:annotation>
             <xsd:appinfo>
                 <sd:schemaDoc>
                     <ddue:summary>
@@ -619,19 +621,17 @@ jonas.jepsen@dlr.de
                 </sd:schemaDoc>
             </xsd:appinfo>
         </xsd:annotation>
-        <xsd:complexType>
-            <xsd:all>
-                <xsd:element name="header" type="headerType"/>
-                <xsd:element minOccurs="0" name="vehicles" type="vehiclesType"/>
-                <xsd:element minOccurs="0" name="missionDefinitions" type="missionDefinitionsType"/>
-                <xsd:element minOccurs="0" name="airports" type="airportsType"/>
-                <xsd:element minOccurs="0" name="flights" type="flightsType"/>
-                <xsd:element minOccurs="0" name="airlines" type="airlinesType"/>
-                <xsd:element minOccurs="0" name="studies" type="studiesType"/>
-                <xsd:element minOccurs="0" name="toolspecific" type="toolspecificType"/>
-            </xsd:all>
-        </xsd:complexType>
-    </xsd:element>
+        <xsd:all>
+            <xsd:element name="header" type="headerType"/>
+            <xsd:element minOccurs="0" name="vehicles" type="vehiclesType"/>
+            <xsd:element minOccurs="0" name="missionDefinitions" type="missionDefinitionsType"/>
+            <xsd:element minOccurs="0" name="airports" type="airportsType"/>
+            <xsd:element minOccurs="0" name="flights" type="flightsType"/>
+            <xsd:element minOccurs="0" name="airlines" type="airlinesType"/>
+            <xsd:element minOccurs="0" name="studies" type="studiesType"/>
+            <xsd:element minOccurs="0" name="toolspecific" type="toolspecificType"/>
+        </xsd:all>
+    </xsd:complexType>
 
 	<xsd:complexType name="UIDGroupDefinitionType">
 


### PR DESCRIPTION
The reason for this change is to be consistent
through all type-definitions in the schema.
The cpacs "xsd:element" now points to the cpacsType "xsd:complexType"