### PR TITLE
Add optional local direction to guidecurves

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -19192,6 +19192,14 @@ jonas.jepsen@dlr.de
 							</xsd:annotation>
 						</xsd:element>
 					</xsd:sequence>
+					<xsd:element minOccurs="0" name="rXDirection" type="pointXYZType">
+							<xsd:annotation>
+									<xsd:documentation>Local direction along which the relative x-coordinates of
+									the guide curve points are defined. For the wing the default is
+									the wing's local x-axis, for the fuselage its the fuselage's local z-axis.
+									</xsd:documentation>
+							</xsd:annotation>
+					</xsd:element>
 				</xsd:sequence>
 				<xsd:attribute name="uID" type="xsd:string" use="required"/>
 			</xsd:extension>


### PR DESCRIPTION
this commit adds an optional local direction to the guidecurvetype along which the relative x-coordinates of the guide curve points are defined.

This direction is used in the new simplified guide curve defintion #458 