### PR TITLE
Content types

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -22126,7 +22126,7 @@ jonas.jepsen@dlr.de
 								definitions (draft version)</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element maxOccurs="0" minOccurs="0" name="rivetJointAreas" type="rivetJointAreasAssemblyType"/>
+					<xsd:element minOccurs="0" name="rivetJointAreas" type="rivetJointAreasAssemblyType"/>
 					<xsd:element minOccurs="0" name="tiedInterfaces" type="tiedInterfacesType"/>
 				</xsd:sequence>
 			</xsd:extension>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -6925,7 +6925,7 @@ jonas.jepsen@dlr.de
 				</sd:schemaDoc>
 			</xsd:appinfo>
 		</xsd:annotation>
-		<xsd:complexContent>
+		<xsd:simpleContent>
 			<xsd:extension base="stringBaseType">
 				<xsd:attribute name="name" type="xsd:string" use="required">
 					<xsd:annotation>
@@ -6934,7 +6934,7 @@ jonas.jepsen@dlr.de
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>
-		</xsd:complexContent>
+		</xsd:simpleContent>
 	</xsd:complexType>
 
 	<xsd:complexType name="comradeVariablesType">
@@ -17837,7 +17837,7 @@ jonas.jepsen@dlr.de
 				</sd:schemaDoc>
 			</xsd:appinfo>
 		</xsd:annotation>
-		<xsd:complexContent>
+		<xsd:simpleContent>
 			<xsd:extension base="stringBaseType">
 				<xsd:attribute name="mode" type="xsd:string">
 					<xsd:annotation>
@@ -17846,7 +17846,7 @@ jonas.jepsen@dlr.de
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>
-		</xsd:complexContent>
+		</xsd:simpleContent>
 	</xsd:complexType>
 
 	<xsd:complexType name="geogenConstraintType">
@@ -18148,7 +18148,7 @@ jonas.jepsen@dlr.de
 				</sd:schemaDoc>
 			</xsd:appinfo>
 		</xsd:annotation>
-		<xsd:complexContent>
+		<xsd:simpleContent>
 			<xsd:extension base="stringBaseType">
 				<xsd:attribute default="1" name="inclusive" type="xsd:boolean">
 					<xsd:annotation>
@@ -18158,7 +18158,7 @@ jonas.jepsen@dlr.de
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>
-		</xsd:complexContent>
+		</xsd:simpleContent>
 	</xsd:complexType>
 
 	<xsd:complexType name="geogenParameterType">
@@ -23478,7 +23478,7 @@ jonas.jepsen@dlr.de
 				</sd:schemaDoc>
 			</xsd:appinfo>
 		</xsd:annotation>
-		<xsd:complexContent>
+		<xsd:simpleContent>
 			<xsd:extension base="stringBaseType">
 				<xsd:attribute name="format">
 					<xsd:simpleType>
@@ -23490,7 +23490,7 @@ jonas.jepsen@dlr.de
 					</xsd:simpleType>
 				</xsd:attribute>
 			</xsd:extension>
-		</xsd:complexContent>
+		</xsd:simpleContent>
 	</xsd:complexType>
 
 	<xsd:complexType name="loadAnalysisType">
@@ -28123,11 +28123,11 @@ jonas.jepsen@dlr.de
 							<xsd:annotation>
 								<xsd:documentation>Parameter value</xsd:documentation>
 							</xsd:annotation>
-							<xsd:complexContent>
+							<xsd:simpleContent>
 								<xsd:extension base="doubleBaseType">
 									<xsd:attribute name="enforce" type="xsd:boolean"/>
 								</xsd:extension>
-							</xsd:complexContent>
+							</xsd:simpleContent>
 						</xsd:complexType>
 					</xsd:element>
 				</xsd:all>


### PR DESCRIPTION
Changed a couple of "complexContent" tags to "simpleContent" because they contain no mixed content or elements.

References:
[complexContent](https://www.w3schools.com/xml/el_complexcontent.asp)
[simpleContent](https://www.w3schools.com/xml/el_simpleContent.asp)