### PR TITLE
Multiple aeromaps

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -2099,10 +2099,10 @@ jonas.jepsen@dlr.de
 			<xsd:appinfo>
 				<sd:schemaDoc>
 					<ddue:summary>
-						<ddue:para>aeroPerformanceMapType</ddue:para>
+						<ddue:para>aeroPerformanceMapRCType</ddue:para>
 					</ddue:summary>
 					<ddue:remarks>
-						<ddue:para>AeroPerformanceMap type, containing a perfomance map
+						<ddue:para>AeroPerformanceMapRC type, containing a perfomance map
 							with aerodynamic data. Array order is: angleOfAttack min-&gt;max
 							then angleOfSideslip then altitude then machNumber</ddue:para>
 					</ddue:remarks>
@@ -2271,17 +2271,17 @@ jonas.jepsen@dlr.de
 		</xsd:complexContent>
 	</xsd:complexType>
 
-	<xsd:complexType name="aeroPerformanceMapsType">
+	<xsd:complexType name="aeroPerformanceMapsRCType">
 
 		<xsd:annotation>
 			<xsd:appinfo>
 				<sd:schemaDoc>
 					<ddue:summary>
-						<ddue:para>aeroPerformanceMapsType</ddue:para>
+						<ddue:para>aeroPerformanceMapsRCType</ddue:para>
 					</ddue:summary>
 					<ddue:remarks>
-						<ddue:para>aeroPerformanceMaps type, containing
-							aeroPerformanceMaps</ddue:para>
+						<ddue:para>aeroPerformanceMapsRC type, containing multiple
+							aeroPerformanceMapRC nodes for different cases</ddue:para>
 					</ddue:remarks>
 				</sd:schemaDoc>
 			</xsd:appinfo>
@@ -3381,7 +3381,7 @@ jonas.jepsen@dlr.de
 								axis system!)</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsType">
+					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsRCType">
 						<xsd:annotation>
 							<xsd:documentation>Calculated aerodynamic performance maps of the
 								airfoil</xsd:documentation>
@@ -16001,7 +16001,7 @@ jonas.jepsen@dlr.de
 								axis system!)</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsType">
+					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsRCType">
 						<xsd:annotation>
 							<xsd:documentation>Calculated aerodynamic performance maps of the
 								fuselage</xsd:documentation>
@@ -18843,7 +18843,7 @@ jonas.jepsen@dlr.de
 								force and moment coefficients</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsType">
+					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsRCType">
 						<xsd:annotation>
 							<xsd:documentation>Calculated aerodynamic performance maps of the
 								full configuration</xsd:documentation>
@@ -40340,7 +40340,7 @@ jonas.jepsen@dlr.de
 								system!)</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsType">
+					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsRCType">
 						<xsd:annotation>
 							<xsd:documentation>Calculated aerodynamic performance maps of the
 								wing</xsd:documentation>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -2235,6 +2235,7 @@ jonas.jepsen@dlr.de
 						</xsd:annotation>
 					</xsd:element>
 				</xsd:sequence>
+				<xsd:attribute name="uID" type="xsd:string" use="required"/>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
@@ -2290,6 +2291,30 @@ jonas.jepsen@dlr.de
 			<xsd:extension base="complexBaseType">
 				<xsd:sequence>
 					<xsd:element maxOccurs="unbounded" name="aeroPerformanceMap" type="aeroPerformanceMapRCType"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="aeroPerformanceMapsType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>aeroPerformanceMapsType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>aeroPerformanceMaps type, containing multiple
+							aeroPerformanceMaps for different cases</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" name="aeroPerformanceMap" type="aeroPerformanceMapType"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -3211,7 +3236,7 @@ jonas.jepsen@dlr.de
 		<xsd:complexContent>
 			<xsd:extension base="complexBaseType">
 				<xsd:all>
-					<xsd:element minOccurs="0" name="aeroPerformanceMap" type="aeroPerformanceMapType"/>
+					<xsd:element minOccurs="0" name="aeroPerformanceMaps" type="aeroPerformanceMapsType"/>
 					<xsd:element minOccurs="0" name="aeroelastics" type="aeroelasticsType"/>
 					<xsd:element minOccurs="0" name="dynamicAircraftModel" type="dynamicAircraftModelAnalysisType"/>
                     <xsd:element minOccurs="0" name="flightDynamics" type="flightDynamicsAnalysisType"/>
@@ -21575,6 +21600,18 @@ jonas.jepsen@dlr.de
 		<xsd:complexContent>
 			<xsd:extension base="complexBaseType">
 				<xsd:sequence>
+					<xsd:element name="name" type="stringBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Name of the AeroPerformanceMap.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element minOccurs="0" name="description" type="stringBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Description of the AeroPerformanceMap.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 					<xsd:element name="machNumber" type="stringVectorBaseType">
 						<xsd:annotation>
 							<xsd:documentation>Mach number</xsd:documentation>


### PR DESCRIPTION
Enabling to store multiple aero performance maps. Could be either for elastic or rigid models, component wise drag breakdown or separate maps for e.g. different drag effects.