### PR TITLE
Spar at rib

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -35770,10 +35770,10 @@ jonas.jepsen@dlr.de
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="complexBaseType">
-				<xsd:sequence>
-					<xsd:element maxOccurs="unbounded" minOccurs="0" name="sparPositionRib" type="wingRibPointType"/>
-					<xsd:element maxOccurs="unbounded" minOccurs="0" name="sparPositionEtaXsi" type="etaXsiPointType"/>
-				</xsd:sequence>
+				<xsd:choice minOccurs="2" maxOccurs="unbounded">
+					<xsd:element name="sparPositionRib" type="wingRibPointType"/>
+					<xsd:element name="sparPositionEtaXsi" type="etaXsiPointType"/>
+				</xsd:choice>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -41477,6 +41477,57 @@ jonas.jepsen@dlr.de
 	</xsd:complexType>
 
 
+	<xsd:complexType name="wingRibPointType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>wingRibPointType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:content>
+							<ddue:para>The wingRibPointType is used to define reference points on ribs.
+								It can be used for rib set definitions (wingRibsPositioningType) as 
+								well as explicit rib definitions (wingRibExplicitPositioningType).</ddue:para>
+						</ddue:content>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:all>
+					<xsd:element name="ribDefinitionUID" type="stringUIDBaseType">
+							<xsd:annotation>
+								<xsd:documentation>
+									The UID of the rib definition. Can be a reference to nodes 
+									of either wingRibsPositioningType or wingRibExplicitPositioningType.
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+					<xsd:element minOccurs="0" name="ribNumber" type="integerBaseType">
+						<xsd:annotation>
+							<xsd:documentation>
+								For references of type wingRibsPositioningType this node indicates the rib number of the rib set. 
+								If not given it defaults to 1.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="xsi" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>
+								Normalized xsi coordinate of the rib point which is measured along the rib 
+								from the start point [0] towards the end point [1].
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:all>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
 	<xsd:complexType name="wingRibsDefinitionType">
 
 		<xsd:annotation>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -35771,7 +35771,8 @@ jonas.jepsen@dlr.de
 		<xsd:complexContent>
 			<xsd:extension base="complexBaseType">
 				<xsd:sequence>
-					<xsd:element maxOccurs="unbounded" minOccurs="2" name="sparPosition" type="sparPositionType"/>
+					<xsd:element maxOccurs="unbounded" minOccurs="0" name="sparPositionRib" type="wingRibPointType"/>
+					<xsd:element maxOccurs="unbounded" minOccurs="0" name="sparPositionEtaXsi" type="etaXsiPointType"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>


### PR DESCRIPTION
Changed the definition of sparPositionType to use etaXsiPointType and added an option for the definition of spar points as rib points.
This PR allows to snap sparPositions to points on ribs. Loop definitions such as spar points defined by ribs which are defined by the same spar point are not forbidden by the schema. But such definitions make no sense and thus should be checked on a user level.
Closes  #544 
